### PR TITLE
Use Github Actions to run golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,22 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,143 @@
+run:
+  timeout: 1m
+
+issues:
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 0
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0
+
+output:
+  sort-results: true
+
+# Uncomment and add a path if needed to exclude
+# skip-dirs:
+#   - some/path
+# skip-files:
+#   - ".*\\.my\\.go$"
+#   - lib/bad.go
+
+# Find the whole list here https://golangci-lint.run/usage/linters/
+linters:
+  disable-all: true
+  enable:
+    - asciicheck # simple linter to check that your code does not contain non-ASCII identifiers
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - deadcode # finds unused code
+    - dupl # tool for code clone detection
+    - durationcheck # check for two durations multiplied together
+    - errcheck # checking for unchecked errors in go programs
+    - errname # check error prefixes and suffixes
+    - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
+    - exportloopref # checks for pointers to enclosing loop variables
+    - goconst # finds repeated strings that could be replaced by a constant
+    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
+    - gomoddirectives # manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
+    - gosec # inspects source code for security problems
+    - gosimple # linter for Go source code that specializes in simplifying a code
+    - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - importas # enforces consistent import aliases
+    - ineffassign # detects when assignments to existing variables are not used
+    - misspell # finds commonly misspelled English words in comments
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil.
+    - noctx # noctx finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - prealloc # finds slice declarations that could potentially be preallocated
+    - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - structcheck # finds unused struct fields
+    - stylecheck # a replacement for golint
+    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
+    - unconvert # Remove unnecessary type conversions
+    - unparam # reports unused function parameters
+    - unused # checks Go code for unused constants, variables, functions and types
+    - varcheck # Finds unused global variables and constants
+    - wastedassign # wastedassign finds wasted assignment statements.
+    - whitespace # find trailing whitespaces
+
+# all available settings of specific linters
+linters-settings:
+  errcheck:
+    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: true
+
+  errorlint:
+    # Check whether fmt.Errorf uses the %w verb for formatting errors. See the readme for caveats
+    errorf: true
+    # Check for plain type assertions and type switches
+    asserts: true
+    # Check for plain error comparisons
+    comparison: true
+
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 2
+
+  dupl:
+    # tokens count to trigger issue, 150 by default
+    threshold: 150
+
+  gomoddirectives:
+    # Allow local `replace` directives. Default is false.
+    replace-local: false
+
+  gosimple:
+    # Select the Go version to target. The default is '1.13'.
+    go: "1.17.6"
+
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    # locale: US
+    # ignore-words:
+    #   - IdP
+
+  nakedret:
+    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
+    max-func-lines: 0
+
+  prealloc:
+    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+    # True by default.
+    simple: true
+    range-loops: true # Report preallocation suggestions on range loops, true by default
+    for-loops: false # Report preallocation suggestions on for loops, false by default
+
+  nolintlint:
+    # Enable to ensure that nolint directives are all used. Default is true.
+    allow-unused: false
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    allow-leading-space: true
+    # Exclude following linters from requiring an explanation.  Default is [].
+    allow-no-explanation: []
+    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+    require-explanation: true
+    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+    require-specific: true
+
+  staticcheck:
+    # Select the Go version to target. The default is '1.13'.
+    go: "1.17.6"
+
+  stylecheck:
+    # Select the Go version to target. The default is '1.13'.
+    go: "1.17.6"
+
+  unparam:
+    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+
+  unused:
+    # Select the Go version to target. The default is '1.13'.
+    go: "1.17.6"

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -15,6 +15,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	loginCmd = "login"
+	addonCmd = "addon"
+)
+
 var cfgFile string
 var cfg *config.Config
 
@@ -110,7 +115,7 @@ var createTokenCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(2),
 	PreRun: initDB,
 	Run: func(cmd *cobra.Command, args []string) {
-		if args[1] != "login" && args[1] != "addon" {
+		if args[1] != loginCmd && args[1] != addonCmd {
 			log.Println("Invalid token type. Allowed values are 'login' or 'addon'")
 			os.Exit(1)
 		}
@@ -120,7 +125,7 @@ var createTokenCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		tok := model.GenerateToken()
-		if args[1] == "login" {
+		if args[1] == loginCmd {
 			u.LoginToken = tok
 			err := model.DB.Save(u).Error
 			if err != nil {
@@ -139,7 +144,7 @@ var createTokenCmd = &cobra.Command{
 			}
 		}
 		log.Printf("Token %s created\n", tok)
-		if args[1] == "login" {
+		if args[1] == loginCmd {
 			log.Printf("Visit %s/login?token=%s to sign in\n", cfg.Server.Address, tok)
 		}
 	},

--- a/model/migration.go
+++ b/model/migration.go
@@ -45,7 +45,6 @@ func addSnapshotSizes() error {
 		}
 		size := storage.GetSnapshotSize(s)
 		DB.Model(&Snapshot{}).Where("key = ?", s).Update("size", size)
-
 	}
 	return nil
 }

--- a/model/model.go
+++ b/model/model.go
@@ -15,7 +15,7 @@ import (
 )
 
 var DB *gorm.DB
-var debug = false
+var debug = false // nolint: unused // it is used in Init
 
 func Init(c *config.Config) error {
 	dbCfg := &gorm.Config{}
@@ -32,14 +32,14 @@ func Init(c *config.Config) error {
 			return err
 		}
 	default:
-		return fmt.Errorf("Unknown database type")
+		return fmt.Errorf("unknown database type")
 		//dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Europe/Budapest"
 		//DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
 		//if err != nil {
 		//	panic(err)
 		//}
 	}
-	DB.AutoMigrate(
+	err = DB.AutoMigrate(
 		&User{},
 		&Bookmark{},
 		&Snapshot{},
@@ -48,6 +48,9 @@ func Init(c *config.Config) error {
 		&Database{},
 		&Resource{},
 	)
+	if err != nil {
+		return fmt.Errorf("auto migration of database '%s' has failed: %w", c.DB.Connection, err)
+	}
 	migrate()
 	return nil
 }
@@ -161,7 +164,7 @@ func CreateUser(username, email string) error {
 
 func GenerateToken() string {
 	b := make([]byte, 32)
-	rand.Read(b)
+	_, _ = rand.Read(b)
 	tok := fmt.Sprintf("%x", b)
 	return tok
 }

--- a/storage/fs/fs.go
+++ b/storage/fs/fs.go
@@ -22,8 +22,7 @@ func (s *FSStorage) Init(dir string) error {
 	if err != nil {
 		return err
 	}
-	mkdir(filepath.Join(s.baseDir, "snapshots"))
-	return nil
+	return mkdir(filepath.Join(s.baseDir, "snapshots"))
 }
 
 func (s *FSStorage) GetSnapshot(key string) io.ReadCloser {
@@ -70,9 +69,9 @@ func (s *FSStorage) SaveSnapshot(key string, snapshot []byte) error {
 	}
 	var b bytes.Buffer
 	w := gzip.NewWriter(&b)
-	w.Write(snapshot)
+	_, _ = w.Write(snapshot)
 	w.Close()
-	return os.WriteFile(path, b.Bytes(), 0644)
+	return os.WriteFile(path, b.Bytes(), 0600)
 }
 
 func (s *FSStorage) SaveResource(key string, resource []byte) error {
@@ -83,9 +82,9 @@ func (s *FSStorage) SaveResource(key string, resource []byte) error {
 	}
 	var b bytes.Buffer
 	w := gzip.NewWriter(&b)
-	w.Write(resource)
+	_, _ = w.Write(resource)
 	w.Close()
-	return os.WriteFile(path, b.Bytes(), 0644)
+	return os.WriteFile(path, b.Bytes(), 0600)
 }
 
 func mkdir(dir string) error {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -19,6 +19,11 @@ type Storage interface {
 	GetResourceSize(string) uint
 }
 
+var ErrUninitialized = errors.New("uninitialized storage")
+var ErrUnknownStorage = errors.New("unknown storage type")
+var ErrSnapshotNotFound = errors.New("snapshot not found")
+var ErrResourceNotFound = errors.New("resource not found")
+
 var store Storage
 
 var storages = map[string]Storage{
@@ -33,41 +38,41 @@ func Init(sType string, sParams string) error {
 		store = s
 		return nil
 	}
-	return errors.New("Unknown storage type")
+	return ErrUnknownStorage
 }
 
 func GetSnapshot(key string) (io.ReadCloser, error) {
 	if store == nil {
-		return nil, errors.New("Uninitialized storage")
+		return nil, ErrUninitialized
 	}
 	r := store.GetSnapshot(key)
 	if r == nil {
-		return nil, errors.New("Snapshot not found")
+		return nil, ErrSnapshotNotFound
 	}
 	return r, nil
 }
 
 func GetResource(key string) (io.ReadCloser, error) {
 	if store == nil {
-		return nil, errors.New("Uninitialized storage")
+		return nil, ErrUninitialized
 	}
 	r := store.GetResource(key)
 	if r == nil {
-		return nil, errors.New("Resource not found")
+		return nil, ErrResourceNotFound
 	}
 	return r, nil
 }
 
 func SaveSnapshot(key string, snapshot []byte) error {
 	if store == nil {
-		return errors.New("Uninitialized storage")
+		return ErrUninitialized
 	}
 	return store.SaveSnapshot(key, snapshot)
 }
 
 func SaveResource(key string, resource []byte) error {
 	if store == nil {
-		return errors.New("Uninitialized storage")
+		return ErrUninitialized
 	}
 	return store.SaveResource(key, resource)
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -16,20 +16,20 @@ func ValidateHTML(h []byte) error {
 		switch tt {
 		case html.ErrorToken:
 			err := doc.Err()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return err
 		case html.StartTagToken:
 			tn, hasAttr := doc.TagName()
 			if bytes.Equal(tn, []byte("script")) {
-				return errors.New("Script tag found")
+				return errors.New("script tag found")
 			}
 			if hasAttr {
 				for {
 					aName, aVal, moreAttr := doc.TagAttr()
 					if bytes.HasPrefix(aName, []byte("on")) && len(aVal) > 0 {
-						return errors.New("Invalid attribute " + string(aName))
+						return errors.New("invalid attribute " + string(aName))
 					}
 					if !moreAttr {
 						break
@@ -38,5 +38,4 @@ func ValidateHTML(h []byte) error {
 			}
 		}
 	}
-	return nil
 }

--- a/webapp/bookmark.go
+++ b/webapp/bookmark.go
@@ -16,6 +16,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const (
+	dateAsc  = "date_asc"
+	dateDesc = "date_desc"
+)
+
 func bookmarks(c *gin.Context) {
 	var bs []*model.Bookmark
 	pageno := getPageno(c)
@@ -27,15 +32,15 @@ func bookmarks(c *gin.Context) {
 	hasSearch := false
 	if err := c.ShouldBind(sp); err != nil {
 		setNotification(c, nError, err.Error(), false)
-		c.AbortWithError(http.StatusBadRequest, err)
+		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
 	} else {
 		if !reflect.DeepEqual(*sp, searchParams{}) {
 			hasSearch = true
 			filterText(sp.Q, sp.SearchInNote, sp.SearchInSnapshot, q, cq)
 			filterOwner(sp.Owner, q, cq)
-			filterFromDate(sp.FromDate, q, cq)
-			filterToDate(sp.ToDate, q, cq)
+			_ = filterFromDate(sp.FromDate, q, cq)
+			_ = filterToDate(sp.ToDate, q, cq)
 			filterDomain(sp.Domain, q, cq)
 			filterTag(sp.Tag, q, cq)
 		}
@@ -43,9 +48,9 @@ func bookmarks(c *gin.Context) {
 	cq.Count(&bookmarkCount)
 	orderBy, _ := c.GetQuery("order_by")
 	switch orderBy {
-	case "date_asc":
+	case dateAsc:
 		q = q.Order("bookmarks.updated_at asc")
-	case "date_desc":
+	case dateDesc:
 		q = q.Order("bookmarks.updated_at desc")
 	default:
 		q = q.Order("bookmarks.updated_at desc")
@@ -74,14 +79,14 @@ func myBookmarks(c *gin.Context) {
 	hasSearch := false
 	if err := c.ShouldBind(sp); err != nil {
 		setNotification(c, nError, err.Error(), false)
-		c.AbortWithError(http.StatusBadRequest, err)
+		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
 	} else {
 		if !reflect.DeepEqual(*sp, searchParams{}) {
 			hasSearch = true
 			filterText(sp.Q, sp.SearchInNote, sp.SearchInSnapshot, q, cq)
-			filterFromDate(sp.FromDate, q, cq)
-			filterToDate(sp.ToDate, q, cq)
+			_ = filterFromDate(sp.FromDate, q, cq)
+			_ = filterToDate(sp.ToDate, q, cq)
 			filterDomain(sp.Domain, q, cq)
 			filterTag(sp.Tag, q, cq)
 			if sp.IsPublic {
@@ -95,9 +100,9 @@ func myBookmarks(c *gin.Context) {
 	cq.Count(&bookmarkCount)
 	orderBy, _ := c.GetQuery("order_by")
 	switch orderBy {
-	case "date_asc":
+	case dateAsc:
 		q = q.Order("bookmarks.updated_at asc")
-	case "date_desc":
+	case dateDesc:
 		q = q.Order("bookmarks.updated_at desc")
 	default:
 		q = q.Order("bookmarks.updated_at desc")
@@ -225,7 +230,7 @@ func addBookmark(c *gin.Context) {
 			})
 			return
 		}
-		sSize = uint(s.Size)
+		sSize = s.Size
 		sKey = key
 	}
 	c.JSON(200, map[string]interface{}{

--- a/webapp/dashboard.go
+++ b/webapp/dashboard.go
@@ -25,7 +25,7 @@ func dashboard(c *gin.Context, u *model.User) {
 	model.DB.Model(&model.Bookmark{}).Where("bookmarks.user_id = ? and bookmarks.updated_at > ? and bookmarks.updated_at < ?", u.ID, today.Truncate(time.Hour*7*24), now).Count(&weeklyBookmarkCount)
 	model.DB.Model(&model.Bookmark{}).Where("bookmarks.user_id = ? and bookmarks.updated_at > ? and bookmarks.updated_at < ?", u.ID, today.AddDate(0, -1, 0), now).Count(&monthlyBookmarkCount)
 	model.DB.Model(&model.Bookmark{}).Where("bookmarks.user_id = ? and bookmarks.updated_at > ? and bookmarks.updated_at < ?", u.ID, today.AddDate(-1, 0, 0), now).Count(&yearlyBookmarkCount)
-	model.DB.Limit(10).Model(u).Preload("Snapshots").Preload("Tags").Order("updated_at desc").Association("Bookmarks").Find(&bs)
+	_ = model.DB.Limit(10).Model(u).Preload("Snapshots").Preload("Tags").Order("updated_at desc").Association("Bookmarks").Find(&bs)
 	model.DB.Limit(20).Table("tags").Select("tags.text as tag, count(bookmarks.user_id) as `count`").Joins("join bookmarks on bookmarks.id == tags.bookmark_id").Where("bookmarks.user_id = ?", u.ID).Group("tags.text").Order("`count` desc, tag asc").Find(&tags)
 	renderHTML(c, http.StatusOK, "dashboard", map[string]interface{}{
 		"WeeklyBookmarkCount":  weeklyBookmarkCount,

--- a/webapp/search.go
+++ b/webapp/search.go
@@ -26,9 +26,9 @@ type searchParams struct {
 	SearchInNote     bool   `form:"search_in_note"`
 }
 
-func filterText(qs string, inNote bool, inSnapshot bool, q, cq *gorm.DB) error {
+func filterText(qs string, inNote bool, inSnapshot bool, q, cq *gorm.DB) {
 	if qs == "" {
-		return nil
+		return
 	}
 	if strings.Contains(qs, "*") {
 		qs = strings.ReplaceAll(qs, "*", "%")
@@ -45,46 +45,42 @@ func filterText(qs string, inNote bool, inSnapshot bool, q, cq *gorm.DB) error {
 		query += " or LOWER(snapshots.text) LIKE LOWER(@query)"
 	}
 	query = "(" + query + ")"
-	q = q.Where(query, sql.Named("query", qs))
-	cq = cq.Where(query, sql.Named("query", qs))
-	return nil
+	q = q.Where(query, sql.Named("query", qs))   // nolint: staticcheck,wastedassign // it is used in later funcs
+	cq = cq.Where(query, sql.Named("query", qs)) // nolint: staticcheck,wastedassign // it is used in later funcs
 }
 
-func filterOwner(o string, q, cq *gorm.DB) error {
+func filterOwner(o string, q, cq *gorm.DB) {
 	if o == "" {
-		return nil
+		return
 	}
 	u := model.GetUser(o)
 	if u == nil {
-		return nil
+		return
 	}
-	q = q.Where("user_id == ? and public == true", u.ID)
-	cq = cq.Where("user_id == ? and public == true", u.ID)
-	return nil
+	q = q.Where("user_id == ? and public == true", u.ID)   // nolint: staticcheck,wastedassign // it is used in later funcs
+	cq = cq.Where("user_id == ? and public == true", u.ID) // nolint: staticcheck,wastedassign // it is used in later funcs
 }
 
-func filterDomain(d string, q, cq *gorm.DB) error {
+func filterDomain(d string, q, cq *gorm.DB) {
 	if d == "" {
-		return nil
+		return
 	}
-	q = q.Where("domain LIKE ?", fmt.Sprintf("%%%s%%", d))
-	cq = cq.Where("domain LIKE ?", fmt.Sprintf("%%%s%%", d))
-	return nil
+	q = q.Where("domain LIKE ?", fmt.Sprintf("%%%s%%", d))   // nolint: staticcheck,wastedassign // it is used in later funcs
+	cq = cq.Where("domain LIKE ?", fmt.Sprintf("%%%s%%", d)) // nolint: staticcheck,wastedassign // it is used in later funcs
 }
 
-func filterTag(t string, q, cq *gorm.DB) error {
+func filterTag(t string, q, cq *gorm.DB) {
 	if t == "" {
-		return nil
+		return
 	}
-	q = q.
+	q = q. // nolint: staticcheck,wastedassign // it is used in later funcs
 		Joins("join bookmark_tags on bookmark_tags.bookmark_id == bookmarks.id").
 		Joins("join tags on bookmark_tags.tag_id == tags.id").
 		Where("tags.text = ?", t)
-	cq = cq.
-		Joins("join bookmark_tags on bookmark_tags.bookmark_id == bookmarks.id").
-		Joins("join tags on bookmark_tags.tag_id == tags.id").
-		Where("tags.text = ?", t)
-	return nil
+	cq = cq. // nolint: staticcheck,wastedassign // it is used in later funcs
+			Joins("join bookmark_tags on bookmark_tags.bookmark_id == bookmarks.id").
+			Joins("join tags on bookmark_tags.tag_id == tags.id").
+			Where("tags.text = ?", t)
 }
 
 func filterFromDate(d string, q, cq *gorm.DB) error {
@@ -95,8 +91,8 @@ func filterFromDate(d string, q, cq *gorm.DB) error {
 	if err != nil {
 		return err
 	}
-	q = q.Where("bookmarks.created_at >= ?", t)
-	cq = cq.Where("bookmarks.created_at >= ?", t)
+	q = q.Where("bookmarks.created_at >= ?", t)   // nolint: staticcheck,wastedassign // it is used in later funcs
+	cq = cq.Where("bookmarks.created_at >= ?", t) // nolint: staticcheck,wastedassign // it is used in later funcs
 	return nil
 }
 
@@ -108,19 +104,12 @@ func filterToDate(d string, q, cq *gorm.DB) error {
 	if err != nil {
 		return err
 	}
-	q = q.Where("bookmarks.created_at <= ?", t)
-	cq = cq.Where("bookmarks.created_at <= ?", t)
+	q = q.Where("bookmarks.created_at <= ?", t)   // nolint: staticcheck,wastedassign // it is used in later funcs
+	cq = cq.Where("bookmarks.created_at <= ?", t) // nolint: staticcheck,wastedassign // it is used in later funcs
 	return nil
 }
 
-func filterPublic(q, cq *gorm.DB) error {
+func filterPublic(q, cq *gorm.DB) {
 	q.Where("public == true")
 	cq.Where("public == true")
-	return nil
-}
-
-func filterPrivate(q, cq *gorm.DB) error {
-	q.Where("public == false")
-	cq.Where("public == false")
-	return nil
 }

--- a/webapp/snapshot.go
+++ b/webapp/snapshot.go
@@ -151,7 +151,9 @@ func snapshotWrapper(c *gin.Context) {
 func deleteSnapshot(c *gin.Context) {
 	u, _ := c.Get("user")
 	session := sessions.Default(c)
-	defer session.Save()
+	defer func() {
+		_ = session.Save()
+	}()
 	bid := c.PostForm("bid")
 	sid := c.PostForm("sid")
 	if bid == "" || sid == "" {

--- a/webapp/user.go
+++ b/webapp/user.go
@@ -23,7 +23,7 @@ func signup(c *gin.Context) {
 	if cfg.(*config.Config).App.DisableSignup {
 		return
 	}
-	if c.Request.Method == "POST" {
+	if c.Request.Method == http.MethodPost {
 		username := c.PostForm("username")
 		email := c.PostForm("email")
 		if username == "" || email == "" {
@@ -148,7 +148,9 @@ func logout(c *gin.Context) {
 		return
 	}
 	session.Delete(SID)
-	session.Save()
+	defer func() {
+		_ = session.Save()
+	}()
 	c.Redirect(http.StatusFound, baseURL("/"))
 }
 
@@ -191,7 +193,9 @@ func generateAddonToken(c *gin.Context) {
 	} else {
 		session.Set("Info", "Token created")
 	}
-	session.Save()
+	defer func() {
+		_ = session.Save()
+	}()
 	c.Redirect(http.StatusFound, baseURL("/profile"))
 }
 
@@ -205,6 +209,8 @@ func deleteAddonToken(c *gin.Context) {
 	} else {
 		setNotification(c, nInfo, "Token deleted", true)
 	}
-	session.Save()
+	defer func() {
+		_ = session.Save()
+	}()
 	c.Redirect(http.StatusFound, baseURL("/profile"))
 }


### PR DESCRIPTION
This PR adds the first Github action to run `golangci-lint`. The changset contains the minor fixes required by the linter.

You can run the linter with the following command after [installing it](https://golangci-lint.run/usage/install/#linux-and-windows):
```sh
$ golangci-lint run
```