### PR TITLE
Bump golangci-lint version to support Go 1.24

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,4 +24,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.64


### PR DESCRIPTION
Your linter job was erroring out, I believe this is the fix.
See https://github.com/golangci/golangci-lint-action/issues/1205#issuecomment-2745335766