### PR TITLE
Embed templates into the binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN chmod +x /entrypoint.sh
 
 # Copy binary and static files
 COPY static ./static
-COPY templates ./templates
 COPY config.yml_sample config.yml
 
 # Modify config.yml to provide some needed default values for running inside the container

--- a/config.yml_sample
+++ b/config.yml_sample
@@ -2,7 +2,6 @@ app:
   log_level: "info" # possible values: error, warning, info, debug, trace
   results_per_page: 30
   disable_signup:  false # set to true to restrict user creation to command line
-  template_dir: "./templates"
   static_dir: "./static"
   # requires Chromium-like browser to be in your $PATH
   create_bookmark_from_webapp: true # set to false to allow create bookmark/snapshot only from the addon

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,6 @@ type App struct {
 	LogLevel                 string `yaml:"log_level"`
 	ResultsPerPage           int64  `yaml:"results_per_page"`
 	DisableSignup            bool   `yaml:"disable_signup"`
-	TemplateDir              string `yaml:"template_dir"`
 	StaticDir                string `yaml:"static_dir"`
 	CreateBookmarkFromWebapp bool   `yaml:"create_bookmark_from_webapp"`
 	WebappSnapshotterTimeout int    `yaml:"webapp_snapshotter_timeout"`

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
+	"os"
 	"syscall"
 	"time"
 
@@ -33,14 +33,16 @@ var disabled = false
 var templates = &Templates{}
 
 func Init(c *config.Config) error {
+	tplFS := os.DirFS(c.App.TemplateDir)
+
 	var err error
-	templates.HTML, err = html.New("mail").ParseGlob(filepath.Join(c.App.TemplateDir, "mail/*html.tpl"))
+	templates.HTML, err = html.New("mail").ParseFS(tplFS, "mail/*html.tpl")
 	if err != nil {
-		return errors.New("failed to parse mail templates. Check your template path")
+		return errors.New("failed to parse mail html templates")
 	}
-	templates.Text, err = text.New("mail").ParseGlob(filepath.Join(c.App.TemplateDir, "mail/*txt.tpl"))
+	templates.Text, err = text.New("mail").ParseFS(tplFS, "mail/*txt.tpl")
 	if err != nil {
-		return errors.New("failed to parse mail templates. Set a valid template path in your config file")
+		return errors.New("failed to parse mail text templates")
 	}
 
 	sc := c.SMTP

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"syscall"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	text "text/template"
 
 	"github.com/asciimoo/omnom/config"
+	templatesfs "github.com/asciimoo/omnom/templates"
 
 	smtp "github.com/xhit/go-simple-mail/v2"
 )
@@ -33,14 +33,12 @@ var disabled = false
 var templates = &Templates{}
 
 func Init(c *config.Config) error {
-	tplFS := os.DirFS(c.App.TemplateDir)
-
 	var err error
-	templates.HTML, err = html.New("mail").ParseFS(tplFS, "mail/*html.tpl")
+	templates.HTML, err = html.New("mail").ParseFS(templatesfs.FS, "mail/*html.tpl")
 	if err != nil {
 		return errors.New("failed to parse mail html templates")
 	}
-	templates.Text, err = text.New("mail").ParseFS(tplFS, "mail/*txt.tpl")
+	templates.Text, err = text.New("mail").ParseFS(templatesfs.FS, "mail/*txt.tpl")
 	if err != nil {
 		return errors.New("failed to parse mail text templates")
 	}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -1,0 +1,7 @@
+package templates
+
+import "embed"
+
+//go:embed *.tpl */*.tpl
+//go:embed *.xml
+var FS embed.FS

--- a/tests/test_config.yml
+++ b/tests/test_config.yml
@@ -2,7 +2,6 @@ app:
   debug: true
   bookmarks_per_page: 20
   disable_signup:  false # set to true to restrict user creation to command line
-  template_dir: "./templates"
   static_dir: "./static"
 server:
   address: "127.0.0.1:7332"

--- a/webapp/activitypub_test.go
+++ b/webapp/activitypub_test.go
@@ -17,7 +17,7 @@ import (
 
 var testCfg = &config.Config{
 	App: config.App{
-		LogLevel:    "debug",
+		LogLevel: "debug",
 	},
 	DB: config.DB{
 		Type:       "sqlite",

--- a/webapp/activitypub_test.go
+++ b/webapp/activitypub_test.go
@@ -18,7 +18,6 @@ import (
 var testCfg = &config.Config{
 	App: config.App{
 		LogLevel:    "debug",
-		TemplateDir: "../templates/",
 	},
 	DB: config.DB{
 		Type:       "sqlite",

--- a/webapp/webapp.go
+++ b/webapp/webapp.go
@@ -8,9 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"net/http"
 	"net/url"
-	"path/filepath"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -132,38 +133,40 @@ func truncate(s string, maxLen int) string {
 	}
 }
 
-func addTemplate(r multitemplate.DynamicRender, rootDir string, hasBase bool, name, filename string) {
+func addTemplate(r multitemplate.DynamicRender, root fs.FS, hasBase bool, name, filename string) {
 	if hasBase {
-		r.AddFromFilesFuncs(name, tplFuncMap, filepath.Join(rootDir, "layout/base.tpl"), filepath.Join(rootDir, filename))
+		r.AddFromFSFuncs(name, tplFuncMap, root, "layout/base.tpl", filename)
 	} else {
-		r.AddFromFilesFuncs(name, tplFuncMap, filepath.Join(rootDir, filename))
+		r.AddFromFSFuncs(name, tplFuncMap, root, filename)
 	}
 }
 
 func createRenderer(rootDir string) multitemplate.Renderer {
+	tplFS := os.DirFS(rootDir)
+
 	r := multitemplate.DynamicRender{}
-	addTemplate(r, rootDir, true, "index", "index.tpl")
-	addTemplate(r, rootDir, true, "dashboard", "dashboard.tpl")
-	addTemplate(r, rootDir, true, "signup", "signup.tpl")
-	addTemplate(r, rootDir, true, "signup-confirm", "signup_confirm.tpl")
-	addTemplate(r, rootDir, true, "login", "login.tpl")
-	addTemplate(r, rootDir, true, "login-confirm", "login_confirm.tpl")
-	addTemplate(r, rootDir, true, "bookmarks", "bookmarks.tpl")
-	addTemplate(r, rootDir, true, "snapshots", "snapshots.tpl")
-	addTemplate(r, rootDir, true, "my-bookmarks", "my_bookmarks.tpl")
-	addTemplate(r, rootDir, true, "profile", "profile.tpl")
-	addTemplate(r, rootDir, true, "snapshot-wrapper", "snapshot_wrapper.tpl")
-	addTemplate(r, rootDir, true, "snapshot-details", "snapshot_details.tpl")
-	addTemplate(r, rootDir, true, "view-bookmark", "view_bookmark.tpl")
-	addTemplate(r, rootDir, true, "edit-bookmark", "edit_bookmark.tpl")
-	addTemplate(r, rootDir, true, "create-bookmark", "create_bookmark.tpl")
-	addTemplate(r, rootDir, true, "snapshot-diff-form", "snapshot_diff_form.tpl")
-	addTemplate(r, rootDir, true, "snapshot-diff", "snapshot_diff.tpl")
-	addTemplate(r, rootDir, true, "snapshot-diff-side-by-side", "snapshot_diff_side_by_side.tpl")
-	addTemplate(r, rootDir, true, "user", "user.tpl")
-	addTemplate(r, rootDir, true, "api", "api.tpl")
-	addTemplate(r, rootDir, true, "error", "error.tpl")
-	addTemplate(r, rootDir, false, "rss", "rss.xml")
+	addTemplate(r, tplFS, true, "index", "index.tpl")
+	addTemplate(r, tplFS, true, "dashboard", "dashboard.tpl")
+	addTemplate(r, tplFS, true, "signup", "signup.tpl")
+	addTemplate(r, tplFS, true, "signup-confirm", "signup_confirm.tpl")
+	addTemplate(r, tplFS, true, "login", "login.tpl")
+	addTemplate(r, tplFS, true, "login-confirm", "login_confirm.tpl")
+	addTemplate(r, tplFS, true, "bookmarks", "bookmarks.tpl")
+	addTemplate(r, tplFS, true, "snapshots", "snapshots.tpl")
+	addTemplate(r, tplFS, true, "my-bookmarks", "my_bookmarks.tpl")
+	addTemplate(r, tplFS, true, "profile", "profile.tpl")
+	addTemplate(r, tplFS, true, "snapshot-wrapper", "snapshot_wrapper.tpl")
+	addTemplate(r, tplFS, true, "snapshot-details", "snapshot_details.tpl")
+	addTemplate(r, tplFS, true, "view-bookmark", "view_bookmark.tpl")
+	addTemplate(r, tplFS, true, "edit-bookmark", "edit_bookmark.tpl")
+	addTemplate(r, tplFS, true, "create-bookmark", "create_bookmark.tpl")
+	addTemplate(r, tplFS, true, "snapshot-diff-form", "snapshot_diff_form.tpl")
+	addTemplate(r, tplFS, true, "snapshot-diff", "snapshot_diff.tpl")
+	addTemplate(r, tplFS, true, "snapshot-diff-side-by-side", "snapshot_diff_side_by_side.tpl")
+	addTemplate(r, tplFS, true, "user", "user.tpl")
+	addTemplate(r, tplFS, true, "api", "api.tpl")
+	addTemplate(r, tplFS, true, "error", "error.tpl")
+	addTemplate(r, tplFS, false, "rss", "rss.xml")
 	return r
 }
 

--- a/webapp/webapp.go
+++ b/webapp/webapp.go
@@ -11,7 +11,6 @@ import (
 	"io/fs"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -19,6 +18,7 @@ import (
 	"github.com/asciimoo/omnom/config"
 	"github.com/asciimoo/omnom/model"
 	"github.com/asciimoo/omnom/storage"
+	"github.com/asciimoo/omnom/templates"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -141,9 +141,7 @@ func addTemplate(r multitemplate.DynamicRender, root fs.FS, hasBase bool, name, 
 	}
 }
 
-func createRenderer(rootDir string) multitemplate.Renderer {
-	tplFS := os.DirFS(rootDir)
-
+func createRenderer(tplFS fs.FS) multitemplate.Renderer {
 	r := multitemplate.DynamicRender{}
 	addTemplate(r, tplFS, true, "index", "index.tpl")
 	addTemplate(r, tplFS, true, "dashboard", "dashboard.tpl")
@@ -353,7 +351,7 @@ func createEngine(cfg *config.Config) *gin.Engine {
 		}
 	}
 	e.NoRoute(notFoundView)
-	e.HTMLRender = createRenderer(cfg.App.TemplateDir)
+	e.HTMLRender = createRenderer(templates.FS)
 	return e
 }
 


### PR DESCRIPTION
Embeds all of the mail and HTML templates directly into the binary so there's no need to copy them around when distributing the binary! Partial fix for https://github.com/asciimoo/omnom/discussions/27.

Testing was straightforward because all of the templates get parsed at startup so we know they're all still functional. I built the binary, removed the local templates directory, and poked around in the UI to confirm that everything still worked.
```
$ go build .
$ rm -rf templates/
$ ./omnom listen
YO
2025-05-22T16:06:47-07:00 | INFO  | webapp/webapp.go:362 > Starting server Address=127.0.0.1:7331
[GIN] 2025/05/22 - 16:06:50 | 200 |    1.843625ms |       127.0.0.1 | GET      "/"
[GIN] 2025/05/22 - 16:06:50 | 304 |     424.125µs |       127.0.0.1 | GET      "/static/css/style.css"
[GIN] 2025/05/22 - 16:06:53 | 200 |   11.500375ms |       127.0.0.1 | GET      "/bookmarks"
...
```

I considered doing this for `static` as well but that's a bigger task because snapshot content gets stored in that directory too so we have to be more careful! I'll probably take that on as a follow-up.