### PR TITLE
Embed static assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Copy binary and static files
-COPY static ./static
-COPY config.yml_sample config.yml
-
 # Modify config.yml to provide some needed default values for running inside the container
+COPY config.yml_sample config.yml
 RUN sed -i -E \
     # Listen to any address by default
     -e 's/address: "127\.0\.0\.1:7331"/address: "0.0.0.0:7331"/' \

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -43,10 +43,7 @@ func initDB(cmd *cobra.Command, args []string) {
 }
 
 func initStorage() {
-	sCfg := map[string]string{
-		"staticDir": cfg.App.StaticDir,
-	}
-	err := storage.Init(cfg.Storage.Type, sCfg)
+	err := storage.Init(cfg.Storage)
 	if err != nil {
 		panic(err)
 	}

--- a/config.yml_sample
+++ b/config.yml_sample
@@ -2,7 +2,6 @@ app:
   log_level: "info" # possible values: error, warning, info, debug, trace
   results_per_page: 30
   disable_signup:  false # set to true to restrict user creation to command line
-  static_dir: "./static"
   # requires Chromium-like browser to be in your $PATH
   create_bookmark_from_webapp: true # set to false to allow create bookmark/snapshot only from the addon
   webapp_snapshotter_timeout: 15 # seconds
@@ -20,6 +19,7 @@ db:
   connection: "./db.sqlite3"
 storage:
   type: "fs"
+  root_dir: "./static/data"
 smtp:
   host: "" # leave it blank to disable sending mails
   port: 25

--- a/static/static.go
+++ b/static/static.go
@@ -1,0 +1,16 @@
+package static
+
+import "embed"
+
+// Embed everything except the data directory which contains user-generated snapshot content
+
+//go:embed css
+//go:embed docs
+//go:embed icons
+//go:embed images
+//go:embed js
+//go:embed omnom.svg
+//go:embed placeholder-image.png
+//go:embed test
+//go:embed webfonts
+var FS embed.FS

--- a/storage/fs/fs.go
+++ b/storage/fs/fs.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/asciimoo/omnom/config"
 )
 
 type FSStorage struct {
@@ -20,9 +22,9 @@ func New() *FSStorage {
 	return &FSStorage{}
 }
 
-func (s *FSStorage) Init(cfg map[string]string) error {
+func (s *FSStorage) Init(sCfg config.Storage) error {
 	var err error
-	s.baseDir, err = filepath.Abs(cfg["staticDir"] + "/data/")
+	s.baseDir, err = filepath.Abs(sCfg.RootDir)
 	if err != nil {
 		return err
 	}

--- a/storage/fs/fs.go
+++ b/storage/fs/fs.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -29,6 +30,14 @@ func (s *FSStorage) Init(sCfg config.Storage) error {
 		return err
 	}
 	return mkdir(filepath.Join(s.baseDir, "snapshots"))
+}
+
+func (s *FSStorage) FS() (fs.FS, error) {
+	root, err := os.OpenRoot(s.baseDir)
+	if err != nil {
+		return nil, err
+	}
+	return root.FS(), nil
 }
 
 func (s *FSStorage) GetSnapshot(key string) io.ReadCloser {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -10,11 +10,12 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/asciimoo/omnom/config"
 	"github.com/asciimoo/omnom/storage/fs"
 )
 
 type Storage interface {
-	Init(map[string]string) error
+	Init(sCfg config.Storage) error
 	GetSnapshot(string) io.ReadCloser
 	GetSnapshotSize(string) uint
 	SaveSnapshot(string, []byte) error
@@ -36,8 +37,8 @@ var storages = map[string]Storage{
 	"fs": fs.New(),
 }
 
-func Init(sType string, sCfg map[string]string) error {
-	if s, ok := storages[sType]; ok {
+func Init(sCfg config.Storage) error {
+	if s, ok := storages[sCfg.Type]; ok {
 		if err := s.Init(sCfg); err != nil {
 			return err
 		}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	iofs "io/fs"
 
 	"github.com/asciimoo/omnom/config"
 	"github.com/asciimoo/omnom/storage/fs"
@@ -16,6 +17,7 @@ import (
 
 type Storage interface {
 	Init(sCfg config.Storage) error
+	FS() (iofs.FS, error)
 	GetSnapshot(string) io.ReadCloser
 	GetSnapshotSize(string) uint
 	SaveSnapshot(string, []byte) error
@@ -46,6 +48,17 @@ func Init(sCfg config.Storage) error {
 		return nil
 	}
 	return ErrUnknownStorage
+}
+
+func FS() iofs.FS {
+	if store == nil {
+		panic(ErrUninitialized)
+	}
+	storeFS, err := store.FS()
+	if err != nil {
+		panic(err)
+	}
+	return storeFS
 }
 
 func GetSnapshot(key string) (io.ReadCloser, error) {

--- a/tests/test_config.yml
+++ b/tests/test_config.yml
@@ -2,7 +2,6 @@ app:
   debug: true
   bookmarks_per_page: 20
   disable_signup:  false # set to true to restrict user creation to command line
-  static_dir: "./static"
 server:
   address: "127.0.0.1:7332"
   # e.g. https://mydomain.tld/xy/
@@ -13,7 +12,6 @@ db:
   connection: "./tests/test_db.sqlite3"
 storage:
   type: "fs"
-  # it should be in the static/ folder
   root: "./static/data"
 smtp:
   host: "" # leave it blank to disable sending mails

--- a/webapp/bookmark.go
+++ b/webapp/bookmark.go
@@ -10,13 +10,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"path"
 	"reflect"
 	"time"
 
 	"github.com/asciimoo/omnom/config"
 	"github.com/asciimoo/omnom/model"
+	"github.com/asciimoo/omnom/static"
 	"github.com/asciimoo/omnom/storage"
 	"github.com/asciimoo/omnom/validator"
 
@@ -191,8 +190,7 @@ func createBookmark(c *gin.Context) {
 	u, _ := cu.(*model.User)
 	urlString := c.PostForm("url")
 	if snapshotJS == "" {
-		jsPath := path.Join(cfg.(*config.Config).App.StaticDir, "js", "snapshot.js")
-		b, err := os.ReadFile(jsPath)
+		b, err := static.FS.ReadFile("js/snapshot.js")
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to read snapshot.js")
 		}

--- a/webapp/webapp.go
+++ b/webapp/webapp.go
@@ -11,7 +11,6 @@ import (
 	"io/fs"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -375,7 +374,7 @@ func createEngine(cfg *config.Config) *gin.Engine {
 		e.StaticFileFS(fmt.Sprintf("/static/%s", f), f, http.FS(static.FS))
 	}
 	// Snapshot content
-	e.Static("/static/data", filepath.Join(cfg.App.StaticDir, "data"))
+	e.Static("/static/data", cfg.Storage.RootDir)
 	for _, ep := range Endpoints {
 		if ep.AuthRequired {
 			registerEndpoint(authorized, ep)


### PR DESCRIPTION
Embeds all of the webapp static assets, like JS and CSS and images, directly into the binary. This removes the need to copy the `static` directory around when distributing the binary. Templates were already embedded into the binary in #46. Completes #27.

I added a new `root_dir` config option for `storage` (since this is what needs the file path) and deprecated the existing `app.static_dir` config now that the assets are embedded. The default location for bookmark content is still `./static/data` to not disrupt users.

It's a little tricky to make both compile-time embedded asset files and the run-time snapshot content fit together because Gin doesn't like multiple levels of wildcards in routes. I wrote a custom static file handler so that everything under `/static` (including `/static/data`) works exactly as it did before. It's a little hacky but it works! I also removed the global gzip middleware in favor of handling it directly in the static file handler. The behavior is the same, just in a different spot!

It'd be nice if we could move snapshot content to a top-level `content` directory to avoid run-time content subdirectories mixed in with compiled-in assets. While I'd like things to be tidy, it's probably not worth the effort and potential user breakage so I didn't include this in the PR.