### PR TITLE
Use modern CSRF protection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/asciimoo/omnom
 go 1.24
 
 require (
+	filippo.io/csrf v0.0.0-20250517103426-cfb6fbb0fbe3
 	github.com/chromedp/cdproto v0.0.0-20250401022514-c504a7d7a18f
 	github.com/chromedp/chromedp v0.13.3
 	github.com/gin-contrib/multitemplate v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gin-contrib/sessions v1.0.2
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/uuid v1.6.0
+	github.com/nicksnyder/go-i18n/v2 v2.6.0
 	github.com/rs/zerolog v1.34.0
 	github.com/sergi/go-diff v1.3.1
 	github.com/spf13/cobra v1.9.1
@@ -16,6 +17,7 @@ require (
 	github.com/tdewolff/parse/v2 v2.7.23
 	github.com/xhit/go-simple-mail/v2 v2.16.0
 	golang.org/x/net v0.38.0
+	golang.org/x/text v0.23.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.25.12
@@ -54,7 +56,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/nicksnyder/go-i18n/v2 v2.6.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
@@ -65,7 +66,6 @@ require (
 	golang.org/x/arch v0.15.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/bytedance/sonic v1.13.2 h1:8/H1FempDZqC4VqjptGo14QQlJx8VdZJegxs6wwfqpQ=
 github.com/bytedance/sonic v1.13.2/go.mod h1:o68xyaF9u2gvVBuGHPlUVCy+ZfmNNO5ETf1+KgkJhz4=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+filippo.io/csrf v0.0.0-20250517103426-cfb6fbb0fbe3 h1:Y4CUtuzXfuQ4qH9EE9GhLDbGOFidCHU6QTHNDV71gEI=
+filippo.io/csrf v0.0.0-20250517103426-cfb6fbb0fbe3/go.mod h1:UKXjDN2cCsNRxbVB9ItZJJDDebd6efD9sN2G64iakPY=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/bytedance/sonic v1.13.2 h1:8/H1FempDZqC4VqjptGo14QQlJx8VdZJegxs6wwfqpQ=

--- a/templates/bookmarks.tpl
+++ b/templates/bookmarks.tpl
@@ -48,11 +48,10 @@
         {{ $uid = .User.ID }}
         {{ end }}
         {{ $page := .Page }}
-        {{ $csrf := .CSRF }}
         {{ $Tr := .Tr }}
         <div class="column bookmark-list">
             {{ range .Bookmarks }}
-                {{ block "bookmark" KVData "Bookmark" . "UID" $uid "Page" $page "CSRF" $csrf "Tr" $Tr }}{{ end }}
+                {{ block "bookmark" KVData "Bookmark" . "UID" $uid "Page" $page "Tr" $Tr }}{{ end }}
             {{ end }}
         </div>
     </div>

--- a/templates/create_bookmark.tpl
+++ b/templates/create_bookmark.tpl
@@ -35,7 +35,6 @@
                     {{ .Tr.Msg "public" }}
                 </label>
             </div>
-            <input type="hidden" name="_csrf" value="{{ .CSRF }}" />
             {{ block "submit" (.Tr.Msg "save") }}{{ end }}
         </div>
     </div>

--- a/templates/dashboard.tpl
+++ b/templates/dashboard.tpl
@@ -40,10 +40,9 @@
       <h4 class="title">{{ .Tr.Msg "my latest bookmarks" }}</h4>
       {{ $uid := .User.ID }}
       {{ $page := .Page }}
-      {{ $csrf := .CSRF }}
       {{ $Tr := .Tr }}
       {{ range .Bookmarks }}
-        {{ block "bookmark" KVData "Bookmark" . "UID" $uid "Page" $page "CSRF" $csrf "Tr" $Tr }}{{ end }}
+        {{ block "bookmark" KVData "Bookmark" . "UID" $uid "Page" $page "Tr" $Tr }}{{ end }}
       {{ end }}
     {{ else }}
       {{ block "warning" KVData "Warning" (.Tr.Msg "no bookmark found") "Tr" .Tr }}{{ end }}

--- a/templates/edit_bookmark.tpl
+++ b/templates/edit_bookmark.tpl
@@ -12,7 +12,6 @@
     </h2>
 
     <form method="post" action="{{ URLFor "Save bookmark" }}">
-        <input type="hidden" name="_csrf" value="{{ .CSRF }}" />
         <input type="hidden" name="id" value="{{ .Bookmark.ID }}" />
         <div class="field">
             <label class="label">Title</label>
@@ -44,7 +43,6 @@
         <form method="post" action="{{ URLFor "Delete bookmark" }}">
             <input class="button is-danger" type="submit" value="Delete this bookmark" />
             <input type="hidden" name="id" value="{{ .Bookmark.ID }}" />
-            <input type="hidden" name="_csrf" value="{{ .CSRF }}" />
         </form>
     </div>
     <h3 class="title">Tags</h3>
@@ -53,7 +51,6 @@
           {{ range .Bookmark.Tags }}
             <span class="tag is-info">{{ .Text }}
                 <form method="post" action="{{ URLFor "Delete tag" }}">
-                    <input type="hidden" name="_csrf" value="{{ $.CSRF }}" />
                     <input type="hidden" name="tid" value="{{ .ID }}"/>
                     <input type="hidden" name="bid" value="{{ $.Bookmark.ID}}"/>
                     <button class="delete" type="submit"></button>
@@ -71,7 +68,6 @@
             <div class="control">
                 <input class="button is-primary" type="submit" value="Add" />
                 <input type="hidden" name="bid" value="{{ .Bookmark.ID }}" />
-                <input type="hidden" name="_csrf" value="{{ .CSRF }}" />
             </div>
         </div>
     </form>
@@ -88,7 +84,6 @@
                             <form method="post" action="{{ URLFor "Delete snapshot" }}">
                                 <h4 class="has-text-dark"><a href="{{ BaseURL "/snapshot" }}?sid={{ .Key }}&bid={{ $.Bookmark.ID }}">{{ .Title }} {{ .CreatedAt | ToDate }}</a>
                                     <input type="hidden" name="bid" value="{{ $.Bookmark.ID }}" />
-                                    <input type="hidden" name="_csrf" value="{{ $.CSRF }}" />
                                     <input type="hidden" name="sid" value="{{ .ID }}" />
                                     <input type="submit" class="button is-danger is-small" value="Delete" />
                                 </h4>

--- a/templates/layout/base.tpl
+++ b/templates/layout/base.tpl
@@ -160,7 +160,7 @@
                   Snapshots <span class="bookmark__snapshot-count">({{len .Bookmark.Snapshots}})</span>
               </summary>
               <div>
-                  {{ block "snapshots" KVData "Snapshots" .Bookmark.Snapshots "IsOwn" (eq .Bookmark.UserID .UID) "CSRF" .CSRF }}{{ end }}
+                  {{ block "snapshots" KVData "Snapshots" .Bookmark.Snapshots "IsOwn" (eq .Bookmark.UserID .UID) }}{{ end }}
               </div>
           </details>
           {{ end }}
@@ -187,7 +187,6 @@
                   <span class="icon is-small"><i class="fas fa-trash"></i></span>
               </button>
               <input type="hidden" name="id" value="{{ .Bookmark.ID }}" />
-              <input type="hidden" name="_csrf" value="{{ .CSRF }}" />
           </form>
           {{ end }}
           <!--<i class="fas fa-heart"></i>
@@ -213,7 +212,6 @@
           <i class="fas fa-pencil-alt"></i>
           <form method="post" action="{{ URLFor "Delete snapshot" }}">
               <input type="hidden" name="bid" value="{{ $s.BookmarkID }}" />
-              <input type="hidden" name="_csrf" value="{{ $.CSRF }}" />
               <input type="hidden" name="sid" value="{{ $s.ID }}" />
               <button class="snapshot__delete" type="submit">
                   <i class="fas fa-trash"></i>

--- a/templates/my_bookmarks.tpl
+++ b/templates/my_bookmarks.tpl
@@ -33,11 +33,10 @@
         {{ $uid = .User.ID }}
         {{ end }}
         {{ $page := .Page }}
-        {{ $csrf := .CSRF }}
         {{ $Tr := .Tr }}
         <div class="column bookmark-list">
             {{ range .Bookmarks }}
-                {{ block "bookmark" KVData "Bookmark" . "UID" $uid "Page" $page "CSRF" $csrf "Tr" $Tr }}{{ end }}
+                {{ block "bookmark" KVData "Bookmark" . "UID" $uid "Page" $page "Tr" $Tr }}{{ end }}
             {{ end }}
         </div>
     </div>

--- a/templates/profile.tpl
+++ b/templates/profile.tpl
@@ -15,7 +15,6 @@
                     <li class="pure-list">
                         <form method="post" action="{{ URLFor "Delete addon token" }}">
                                 <code class="has-text-dark">{{ .Text }}</code>
-                                <input type="hidden" name="_csrf" value="{{ $.CSRF }}" />
                                 <input type="hidden" name="id" value="{{ .ID }}" />
                                 <input type="submit" class="button is-danger is-small" value="{{ .Tr.Msg "delete" }}" />
                         </form>
@@ -28,7 +27,6 @@
     {{ else }}
         <div class="columns is-mobile"><div class="column is-narrow">
             <form method="post">
-                <input type="hidden" name="_csrf" value="{{ $.CSRF }}" />
                 <input type="submit" class="button is-primary" value="{{ .Tr.Msg "show addon tokens" }}" />
             </form>
         </div></div>

--- a/webapp/webapp.go
+++ b/webapp/webapp.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
 
+	"filippo.io/csrf"
 	"github.com/gin-contrib/multitemplate"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
@@ -173,14 +174,12 @@ func render(c *gin.Context, status int, page string, vars map[string]interface{}
 	session := sessions.Default(c)
 	u, _ := c.Get("user")
 	cfg, _ := c.Get("config")
-	csrf, _ := c.Get("_csrf")
 	l, _ := c.Get("localizer")
 	tplVars := gin.H{
 		"Page":                  page,
 		"User":                  u,
 		"DisableSignup":         cfg.(*config.Config).App.DisableSignup,
 		"AllowBookmarkCreation": cfg.(*config.Config).App.CreateBookmarkFromWebapp,
-		"CSRF":                  csrf,
 		"OAuth":                 cfg.(*config.Config).OAuth,
 		"Tr":                    l.(*localization.Localizer),
 	}
@@ -240,7 +239,6 @@ func render(c *gin.Context, status int, page string, vars map[string]interface{}
 }
 
 func renderJSON(c *gin.Context, status int, vars map[string]interface{}) {
-	delete(vars, "CSRF")
 	delete(vars, "DisableSignup")
 	delete(vars, "OAuth")
 	c.IndentedJSON(status, vars)
@@ -504,39 +502,17 @@ func LocalizationMiddleware(cfg *config.Config) gin.HandlerFunc {
 }
 
 func CSRFMiddleware() gin.HandlerFunc {
+	protection := csrf.New()
 	return func(c *gin.Context) {
 		if strings.HasSuffix(c.HandlerName(), ".addBookmark") || strings.HasSuffix(c.HandlerName(), ".addResource") {
 			c.Next()
 			return
 		}
-		newToken := model.GenerateToken()
-		c.Set("_csrf", newToken)
-		session := sessions.Default(c)
-		prevToken := session.Get("_csrf")
-		session.Set("_csrf", newToken)
-		err := session.Save()
+		err := protection.Check(c.Request)
 		if err != nil {
-			_ = c.Error(fmt.Errorf("error saving context: %w", err))
-		}
-		if c.Request.Method != POST {
-			c.Next()
+			c.String(403, err.Error())
+			c.Abort()
 			return
-		}
-		uname := session.Get(SID)
-		if uname != nil {
-			if t := c.Request.FormValue("_csrf"); t == "" || prevToken != t {
-				tok := c.PostForm("token")
-				if tok == "" {
-					tok = c.Query("token")
-				}
-				u := model.GetUserBySubmissionToken(tok)
-				if u == nil {
-					log.Error().Msg("CSRF token mismatch")
-					c.String(400, "CSRF token mismatch")
-					c.Abort()
-					return
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
Use modern CSRF protection from https://pkg.go.dev/filippo.io/csrf. This fixes invalid CSRF token errors when opening more than one page and trying to edit e.g. bookmark tags. It also simplifies templates by not needing a CSRF token anywhere.

The new implementation is very different because it is stateless! See https://github.com/golang/go/issues/73626 for the background on why this makes sense and is a secure approach. This package is a full prototype of the new `net/http.CrossOriginProtection` that [will be available in Go 1.25](https://go-review.googlesource.com/c/go/+/674936), I just wanted to implement this sooner because the token errors annoyed me.